### PR TITLE
Add permission to configure retention in CW LogGroups

### DIFF
--- a/examples/fargate/cloudwatchlogs/permissions.json
+++ b/examples/fargate/cloudwatchlogs/permissions.json
@@ -6,7 +6,9 @@
 			"logs:CreateLogStream",
 			"logs:CreateLogGroup",
 			"logs:DescribeLogStreams",
-			"logs:PutLogEvents"
+			"logs:PutLogEvents",
+			"logs:PutRetentionPolicy",
+                        "logs:DeleteRetentionPolicy"
 		],
 		"Resource": "*"
 	}]


### PR DESCRIPTION
This is based on the following SIM from an external customer. Please test before merging: https://sim.amazon.com/issues/AWSDocsSchedule-27532

Page URL

https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html Issue type:

Incomplete information
Name:

[none provided]
Email:
l**a@dock.tech

Trying to do:
Enable Retention in logGroup over the EKS Fargate LogRouter Make Better:

The IAM Policy recommended in this documentation, not has permission to configure retention in CW LogGroups.

https://raw.githubusercontent.com/aws-samples/amazon-eks-fluent-logging-examples/mainline/examples/fargate/cloudwatchlogs/permissions.json

This policy needs add the follow permissions:

"logs:PutRetentionPolicy"
"logs:DeleteRetentionPolicy"

*Issue #, if available (include [keywords](https://help.github.com/articles/closing-issues-using-keywords/) to close issue as applicable, e.g. "fixes <##>"):*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
